### PR TITLE
Update examples

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -7,8 +7,20 @@ Ensure your device works with this simple test.
     :caption: examples/bluefruitconnect_simpletest.py
     :linenos:
 
-This test demonstrates controlling an Adafruit Crickit board with Bluetooth.
+This example demonstrates receiving button presses from the Control Pad.
 
-.. literalinclude:: ../examples/bluefruitconnect_accelerometer_packet_test.py
-    :caption: examples/bluefruitconnect_accelerometer_packet_test.py
+.. literalinclude:: ../examples/bluefruitconnect_controlpad.py
+    :caption: examples/bluefruitconnect_controlpad.py
+    :linenos:
+
+This example demonstrates receiving sensor data from the Controller.
+
+.. literalinclude:: ../examples/bluefruitconnect_sensors.py
+    :caption: examples/bluefruitconnect_sensors.py
+    :linenos:
+
+This example demonstrates receiving text from the UART interface.
+
+.. literalinclude:: ../examples/bluefruitconnect_uart.py
+    :caption: examples/bluefruitconnect_uart.py
     :linenos:

--- a/examples/bluefruitconnect_controlpad.py
+++ b/examples/bluefruitconnect_controlpad.py
@@ -1,0 +1,56 @@
+# Basic structure example for using the BLE Connect Control Pad
+# To use, start this program, and start the Adafruit Bluefruit LE Connect app.
+# Connect, and then select Controller-> Control Pad.
+
+from adafruit_ble import BLERadio
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from adafruit_ble.services.nordic import UARTService
+from adafruit_bluefruit_connect.packet import Packet
+# Only the packet classes that are imported will be known to Packet.
+from adafruit_bluefruit_connect.button_packet import ButtonPacket
+
+ble = BLERadio()
+uart_server = UARTService()
+advertisement = ProvideServicesAdvertisement(uart_server)
+
+while True:
+    print("WAITING...")
+    # Advertise when not connected.
+    ble.start_advertising(advertisement)
+    while not ble.connected:
+        pass
+
+    # Connected
+    ble.stop_advertising()
+    print("CONNECTED")
+
+    # Loop and read packets
+    while ble.connected:
+
+        # Keeping trying until a good packet is received
+        try:
+            packet = Packet.from_stream(uart_server)
+        except ValueError:
+            continue
+
+        # Only handle button packets
+        if isinstance(packet, ButtonPacket) and packet.pressed:
+            if packet.button == ButtonPacket.UP:
+                print("Button UP")
+            if packet.button == ButtonPacket.DOWN:
+                print("Button DOWN")
+            if packet.button == ButtonPacket.LEFT:
+                print("Button LEFT")
+            if packet.button == ButtonPacket.RIGHT:
+                print("Button RIGHT")
+            if packet.button == ButtonPacket.BUTTON_1:
+                print("Button 1")
+            if packet.button == ButtonPacket.BUTTON_2:
+                print("Button 2")
+            if packet.button == ButtonPacket.BUTTON_3:
+                print("Button 3")
+            if packet.button == ButtonPacket.BUTTON_4:
+                print("Button 4")
+
+    # Disconnected
+    print("DISCONNECTED")

--- a/examples/bluefruitconnect_sensors.py
+++ b/examples/bluefruitconnect_sensors.py
@@ -1,0 +1,61 @@
+# Basic structure example for using the BLE Connect Controller sensors
+# To use, start this program, and start the Adafruit Bluefruit LE Connect app.
+# Connect, and then select Controller and enable the sensors
+
+from adafruit_ble import BLERadio
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from adafruit_ble.services.nordic import UARTService
+from adafruit_bluefruit_connect.packet import Packet
+# Only the packet classes that are imported will be known to Packet.
+from adafruit_bluefruit_connect.accelerometer_packet import AccelerometerPacket
+from adafruit_bluefruit_connect.gyro_packet import GyroPacket
+from adafruit_bluefruit_connect.location_packet import LocationPacket
+from adafruit_bluefruit_connect.magnetometer_packet import MagnetometerPacket
+from adafruit_bluefruit_connect.quaternion_packet import QuaternionPacket
+
+ble = BLERadio()
+uart_server = UARTService()
+advertisement = ProvideServicesAdvertisement(uart_server)
+
+while True:
+    print("WAITING...")
+    # Advertise when not connected.
+    ble.start_advertising(advertisement)
+    while not ble.connected:
+        pass
+
+    # Connected
+    ble.stop_advertising()
+    print("CONNECTED")
+
+    # Loop and read packets
+    while ble.connected:
+
+        # Keeping trying until a good packet is received
+        try:
+            packet = Packet.from_stream(uart_server)
+        except ValueError:
+            continue
+
+        # Accelerometer
+        if isinstance(packet, AccelerometerPacket):
+            print("Accelerometer:", packet.x, packet.y, packet.z)
+
+        # Gyro
+        if isinstance(packet, GyroPacket):
+            print("Gyro:", packet.x, packet.y, packet.z)
+
+        # Location
+        if isinstance(packet, LocationPacket):
+            print("Location:", packet.latitude, packet.longitude, packet.altitude)
+
+        # Magnetometer
+        if isinstance(packet, MagnetometerPacket):
+            print("Magnetometer", packet.x, packet.y, packet.z)
+
+        # Quaternion
+        if isinstance(packet, QuaternionPacket):
+            print("Quaternion:", packet.x, packet.y, packet.z, packet.w)
+
+    # Disconnected
+    print("DISCONNECTED")

--- a/examples/bluefruitconnect_uart.py
+++ b/examples/bluefruitconnect_uart.py
@@ -1,27 +1,34 @@
-# Stream accelerometer data from your phone or tablet.
+# Basic example for using the BLE Connect UART
 # To use, start this program, and start the Adafruit Bluefruit LE Connect app.
-# Connect and go to the Controller screen. Turn on
-# STREAM SENSOR DATA -> Accelerometer to send data from the device's
-# accelerometer. See how it matches what this prints.
+# Connect, and then select UART
 
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
 from adafruit_ble.services.nordic import UARTService
 from adafruit_bluefruit_connect.packet import Packet
-# Only the packet classes that are imported will be known to Packet.
-from adafruit_bluefruit_connect.accelerometer_packet import AccelerometerPacket
 
 ble = BLERadio()
 uart_server = UARTService()
 advertisement = ProvideServicesAdvertisement(uart_server)
 
 while True:
+    print("WAITING...")
     # Advertise when not connected.
     ble.start_advertising(advertisement)
     while not ble.connected:
         pass
 
+    # Connected
+    ble.stop_advertising()
+    print("CONNECTED")
+
+    # Loop and read packets
     while ble.connected:
-        packet = Packet.from_stream(uart_server)
-        if isinstance(packet, AccelerometerPacket):
-            print(packet.x, packet.y, packet.z)
+        if uart_server.in_waiting:
+            raw_bytes = uart_server.read(uart_server.in_waiting)
+            text = raw_bytes.decode().strip()
+            print("raw bytes =", raw_bytes)
+            print("text =", text)
+
+    # Disconnected
+    print("DISCONNECTED")

--- a/examples/bluefruitconnect_uart.py
+++ b/examples/bluefruitconnect_uart.py
@@ -5,7 +5,6 @@
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
 from adafruit_ble.services.nordic import UARTService
-from adafruit_bluefruit_connect.packet import Packet
 
 ble = BLERadio()
 uart_server = UARTService()


### PR DESCRIPTION
New examples include:

- `bluefruitconnect_sensors.py` - replaces `bluefruitconnect_accelerometer_packet_test.py` and adds all available sensors
- `bluefruitconnect_uart.py` - prints text received from UART interface
- `bluefruitconnect_controlpad.py` - prints messages for each Control Pad button