### PR TITLE
Fix pypi install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,5 @@ setup(
     keywords="adafruit ble bluefruit bluetooth micropython circuitpython",
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    py_packages=["adafruit_bluefruit_connect"],
+    packages=["adafruit_bluefruit_connect"],
 )

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,5 @@ setup(
     keywords="adafruit ble bluefruit bluetooth micropython circuitpython",
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    py_modules=["adafruit_bluefruit_connect"],
+    py_packages=["adafruit_bluefruit_connect"],
 )


### PR DESCRIPTION
This is a multifile package, but setup.py thought it was a single-file module.

@makermelissa This is essentially the same fix you just found for blinka displayio.