### PR TITLE
Fix failure in from_stream method

### DIFF
--- a/adafruit_bluefruit_connect/packet.py
+++ b/adafruit_bluefruit_connect/packet.py
@@ -103,7 +103,7 @@ class Packet:
                 break
             # Didn't find a packet start. Loop and try again.
 
-        header = start + packet_type
+        header = bytes(start + packet_type)
         packet_class = cls._type_to_class.get(header, None)
         if not packet_class:
             raise ValueError("Unregistered packet type {}".format(header))


### PR DESCRIPTION
`from_stream` method of the `Packet` class fails when getting the `packet_class` from the `_type_to_class` dictionary because `header` is a bytearray and not hashable. This change makes `header` hashable and corrects the error.