### PR TITLE
Add support for a TextPacket, as sent using the UART module in the Ad…

### DIFF
--- a/adafruit_bluefruit_connect/packet.py
+++ b/adafruit_bluefruit_connect/packet.py
@@ -94,6 +94,7 @@ class Packet:
             if not start:
                 # Timeout: nothing read.
                 return None
+
             if start == b"!":
                 # Found start of packet.
                 packet_type = stream.read(1)
@@ -101,17 +102,16 @@ class Packet:
                     # Timeout: nothing more read.
                     return None
                 break
-            # Didn't find a packet start.
-            else:
-                text_packet_cls = cls._type_to_class.get(b"TX", None)
-                # Is TextPacket registered?
-                # If so, read an entire line and pass that to TextPacket.
-                if text_packet_cls:
-                    ln = stream.readline()
-                    packet = bytes(start + ln)
-                    return text_packet_cls(packet)
 
-                # else loop and try again.
+            # Didn't find a packet start.
+	    text_packet_cls = cls._type_to_class.get(b"TX", None)
+	    # Is TextPacket registered?
+	    # If so, read an entire line and pass that to TextPacket.
+	    if text_packet_cls:
+		packet = bytes(start + stream.readline())
+		return text_packet_cls(packet)
+
+	    # else loop and try again.
 
         header = bytes(start + packet_type)
         packet_class = cls._type_to_class.get(header, None)

--- a/adafruit_bluefruit_connect/packet.py
+++ b/adafruit_bluefruit_connect/packet.py
@@ -104,12 +104,12 @@ class Packet:
                 break
 
             # Didn't find a packet start.
-            text_packet_cls = cls._type_to_class.get(b"TX", None)
-            # Is TextPacket registered?
-            # If so, read an entire line and pass that to TextPacket.
-            if text_packet_cls:
+            raw_text_packet_cls = cls._type_to_class.get(b"RT", None)
+            # Is RawTextPacket registered?
+            # If so, read an entire line and pass that to RawTextPacket.
+            if raw_text_packet_cls:
                 packet = bytes(start + stream.readline())
-                return text_packet_cls(packet)
+                return raw_text_packet_cls(packet)
 
             # else loop and try again.
 

--- a/adafruit_bluefruit_connect/packet.py
+++ b/adafruit_bluefruit_connect/packet.py
@@ -101,7 +101,17 @@ class Packet:
                     # Timeout: nothing more read.
                     return None
                 break
-            # Didn't find a packet start. Loop and try again.
+            # Didn't find a packet start.
+            else:
+                text_packet_cls = cls._type_to_class.get(b"TX", None)
+                # Is TextPacket registered?
+                # If so, read an entire line and pass that to TextPacket.
+                if text_packet_cls:
+                    ln = stream.readline()
+                    packet = bytes(start + ln)
+                    return text_packet_cls(packet)
+
+                # else loop and try again.
 
         header = bytes(start + packet_type)
         packet_class = cls._type_to_class.get(header, None)

--- a/adafruit_bluefruit_connect/packet.py
+++ b/adafruit_bluefruit_connect/packet.py
@@ -104,14 +104,14 @@ class Packet:
                 break
 
             # Didn't find a packet start.
-	    text_packet_cls = cls._type_to_class.get(b"TX", None)
-	    # Is TextPacket registered?
-	    # If so, read an entire line and pass that to TextPacket.
-	    if text_packet_cls:
-		packet = bytes(start + stream.readline())
-		return text_packet_cls(packet)
+            text_packet_cls = cls._type_to_class.get(b"TX", None)
+            # Is TextPacket registered?
+            # If so, read an entire line and pass that to TextPacket.
+            if text_packet_cls:
+                packet = bytes(start + stream.readline())
+                return text_packet_cls(packet)
 
-	    # else loop and try again.
+            # else loop and try again.
 
         header = bytes(start + packet_type)
         packet_class = cls._type_to_class.get(header, None)

--- a/adafruit_bluefruit_connect/raw_text_packet.py
+++ b/adafruit_bluefruit_connect/raw_text_packet.py
@@ -3,17 +3,18 @@
 # SPDX-License-Identifier: MIT
 
 """
-`adafruit_bluefruit_connect.text_packet`
+`adafruit_bluefruit_connect.raw_text_packet`
 ====================================================
 
-Bluefruit Connect App text data packet.
+Bluefruit Connect App raw text data packet.
 
-Note that the text data packet is different from those used by the
+Note that the raw text data packet is different from those used by the
 Controller module (e.g. Accelerometer, Control Pad, and Color Picker).
 Those use the bytes "!x" (where x is specific to the type of packet),
 followed by data specific to the packet, followed by a checksum.
 The UART text sender instead sends the bytes followed by a newline.
-There is no length indicator, no checksum, etc.
+There is no length indicator, no checksum, etc. Of course, that also
+precludes the use of an "!" at the beginning of the string.
 
 Consequently, this packet type is MUCH simpler than the other packet types.
 
@@ -24,13 +25,13 @@ Consequently, this packet type is MUCH simpler than the other packet types.
 from .packet import Packet
 
 
-class TextPacket(Packet):
+class RawTextPacket(Packet):
     """A packet containing a text string."""
 
-    _TYPE_HEADER = b"TX"
+    _TYPE_HEADER = b"RT"
 
     def __init__(self, text):
-        """Construct a TextPacket from a binary string."""
+        """Construct a RawTextPacket from a binary string."""
         if isinstance(text, bytes):
             self._text = text.strip()
         else:
@@ -43,4 +44,4 @@ class TextPacket(Packet):
 
 
 # Register this class with the superclass. This allows the user to import only what is needed.
-TextPacket.register_packet_type()
+RawTextPacket.register_packet_type()

--- a/adafruit_bluefruit_connect/text_packet.py
+++ b/adafruit_bluefruit_connect/text_packet.py
@@ -41,5 +41,6 @@ class TextPacket(Packet):
         """Return the text associated with the object."""
         return self._text
 
+
 # Register this class with the superclass. This allows the user to import only what is needed.
 TextPacket.register_packet_type()

--- a/adafruit_bluefruit_connect/text_packet.py
+++ b/adafruit_bluefruit_connect/text_packet.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2021 Tony Hansen
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_bluefruit_connect.text_packet`
+====================================================
+
+Bluefruit Connect App text data packet.
+
+Note that the text data packet is different from those used by the
+Controller module (e.g. Accelerometer, Control Pad, and Color Picker).
+Those use the bytes "!x" (where x is specific to the type of packet),
+followed by data specific to the packet, followed by a checksum.
+The UART text sender instead sends the bytes followed by a newline.
+There is no length indicator, no checksum, etc.
+
+Consequently, this packet type is MUCH simpler than the other packet types.
+
+* Author(s): Tony Hansen
+
+"""
+
+import struct
+
+from .packet import Packet
+
+
+class TextPacket(Packet):
+    """A packet containing a text string."""
+
+    _TYPE_HEADER = b"TX"
+
+    def __init__(self, text):
+        """Construct a TextPacket from a binary string."""
+        if isinstance(text, bytes):
+            self._text = text.strip()
+        else:
+            raise ValueError("Text must be a bytes string")
+
+    @property
+    def text(self):
+        """Return the text associated with the object."""
+        return self._text
+
+# Register this class with the superclass. This allows the user to import only what is needed.
+TextPacket.register_packet_type()

--- a/adafruit_bluefruit_connect/text_packet.py
+++ b/adafruit_bluefruit_connect/text_packet.py
@@ -21,8 +21,6 @@ Consequently, this packet type is MUCH simpler than the other packet types.
 
 """
 
-import struct
-
 from .packet import Packet
 
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -24,3 +24,11 @@ This example demonstrates receiving text from the UART interface.
 .. literalinclude:: ../examples/bluefruitconnect_uart.py
     :caption: examples/bluefruitconnect_uart.py
     :linenos:
+
+This example demonstrates receiving both a color (as in simpletest above)
+and raw text (using RawTextPacket).
+
+.. literalinclude:: ../examples/bluefruitconnect_simpletest.py
+    :caption: examples/bluefruitconnect_simpletest.py
+    :linenos:
+

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -31,4 +31,3 @@ and raw text (using RawTextPacket).
 .. literalinclude:: ../examples/bluefruitconnect_simpletest.py
     :caption: examples/bluefruitconnect_simpletest.py
     :linenos:
-

--- a/examples/bluefruitconnect_simpletest2.py
+++ b/examples/bluefruitconnect_simpletest2.py
@@ -33,4 +33,3 @@ while True:
         elif isinstance(packet, TextPacket):
             print("Received Text Packet:")
             print(packet.text)
-

--- a/examples/bluefruitconnect_simpletest2.py
+++ b/examples/bluefruitconnect_simpletest2.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+# Print out the color data from ColorPackets and text data from TextPackets.
+# To use, start this program, and start the Adafruit Bluefruit LE Connect app.
+# Connect, and then select colors on the Controller->Color Picker screen.
+# Select text by entering the UART screen and sending in in a string.
+# (Do NOT use a "!" as part of your string.)
+
+from adafruit_ble import BLERadio
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from adafruit_ble.services.nordic import UARTService
+from adafruit_bluefruit_connect.packet import Packet
+
+# Only the packet classes that are imported will be known to Packet.
+from adafruit_bluefruit_connect.color_packet import ColorPacket
+from adafruit_bluefruit_connect.text_packet import TextPacket
+
+ble = BLERadio()
+uart_server = UARTService()
+advertisement = ProvideServicesAdvertisement(uart_server)
+
+while True:
+    # Advertise when not connected.
+    ble.start_advertising(advertisement)
+    while not ble.connected:
+        pass
+
+    while ble.connected:
+        packet = Packet.from_stream(uart_server)
+        if isinstance(packet, ColorPacket):
+            print(packet.color)
+        elif isinstance(packet, TextPacket):
+            print("Received Text Packet:")
+            print(packet.text)
+

--- a/examples/bluefruitconnect_simpletest2.py
+++ b/examples/bluefruitconnect_simpletest2.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
-# Print out the color data from ColorPackets and text data from TextPackets.
+# Print out the color data from ColorPackets and text data from RawTextPackets.
 # To use, start this program, and start the Adafruit Bluefruit LE Connect app.
 # Connect, and then select colors on the Controller->Color Picker screen.
-# Select text by entering the UART screen and sending in in a string.
-# (Do NOT use a "!" as part of your string.)
+# Select text by entering the UART screen and sending a string.
+# (Do NOT use a "!" at the start of your string.)
 
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
@@ -14,7 +14,7 @@ from adafruit_bluefruit_connect.packet import Packet
 
 # Only the packet classes that are imported will be known to Packet.
 from adafruit_bluefruit_connect.color_packet import ColorPacket
-from adafruit_bluefruit_connect.text_packet import TextPacket
+from adafruit_bluefruit_connect.raw_text_packet import RawTextPacket
 
 ble = BLERadio()
 uart_server = UARTService()
@@ -30,6 +30,6 @@ while True:
         packet = Packet.from_stream(uart_server)
         if isinstance(packet, ColorPacket):
             print(packet.color)
-        elif isinstance(packet, TextPacket):
-            print("Received Text Packet:")
+        elif isinstance(packet, RawTextPacket):
+            print("Received Raw Text Packet:")
             print(packet.text)


### PR DESCRIPTION
Add support for a TextPacket, as sent using the UART module in the AdaFruit BlueTooth app

This code provides an exception case to the Packet creation logic, similar to how the sample Arduino BLE code for the LED Glasses also has an exception case when the UART stream has data that does not start with a "!".