### PR TITLE
Add the RawTextPacket class to the documentation

### DIFF
--- a/adafruit_bluefruit_connect/packet.py
+++ b/adafruit_bluefruit_connect/packet.py
@@ -81,7 +81,10 @@ class Packet:
         set on stream, using its own preset timeout.
         Return None if there was no input, otherwise return an instance
         of one of the packet classes registered with ``Packet``.
-        Raise an Error if the packet was not recognized or was malformed
+        Raise an Error if the packet was not recognized or was malformed.
+
+        If a packet of type "RT" (like ``RawTextPacket``) is registered, it will be
+        used to return the raw data line when no packet type was recognized.
 
         :param stream stream: an input stream that provides standard stream read operations,
           such as ``ble.UARTServer`` or ``busio.UART``.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,3 +30,6 @@
 
 .. automodule:: adafruit_bluefruit_connect.quaternion_packet
    :members:
+
+.. automodule:: adafruit_bluefruit_connect.raw_text_packet
+   :members:


### PR DESCRIPTION
And mention its use in `Packet.from_stream()`.