### PR TITLE
Fix creating a color packet with an int

### DIFF
--- a/adafruit_bluefruit_connect/color_packet.py
+++ b/adafruit_bluefruit_connect/color_packet.py
@@ -34,7 +34,7 @@ class ColorPacket(Packet):
           or an int color value ``0xRRGGBB``
         """
         if isinstance(color, int):
-            self._color = tuple(color.to_bytes("BBB", "big"))
+            self._color = tuple(color.to_bytes(3, "big"))
         elif len(color) == 3 and all(0 <= c <= 255 for c in color):
             self._color = color
         else:


### PR DESCRIPTION
Fixes creating a ColorPacket from an int (like rainbowio.colorwheel)
```py
from adafruit_bluefruit_connect.color_packet import ColorPacket
c = ColorPacket(0xFF0080)
print(c.color)
```
Before:
```
code.py output:
Traceback (most recent call last):
  File "code.py", line 2, in <module>
  File "adafruit_bluefruit_connect/color_packet.py", line 37, in __init__
TypeError: can't convert str to int
```
After:
```
code.py output:
(255, 0, 128)
```