### PR TITLE
Type annotations

### DIFF
--- a/adafruit_bluefruit_connect/_xyz_packet.py
+++ b/adafruit_bluefruit_connect/_xyz_packet.py
@@ -16,11 +16,6 @@ from __future__ import annotations
 
 import struct
 
-try:
-    from typing import Generator, Union, Dict, Optional, Any  # adjust these as needed
-except ImportError:
-    pass
-
 from .packet import Packet
 
 

--- a/adafruit_bluefruit_connect/_xyz_packet.py
+++ b/adafruit_bluefruit_connect/_xyz_packet.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import struct
 
 try:
-    from typing import Generator, Union, Dict, Optional, Any # adjust these as needed
+    from typing import Generator, Union, Dict, Optional, Any  # adjust these as needed
 except ImportError:
     pass
 

--- a/adafruit_bluefruit_connect/_xyz_packet.py
+++ b/adafruit_bluefruit_connect/_xyz_packet.py
@@ -12,7 +12,14 @@ Bluefruit Connect App superclass for all data packets with (x, y, z) values
 
 """
 
+from __future__ import annotations
+
 import struct
+
+try:
+    from typing import Generator, Union, Dict, Optional, Any # adjust these as needed
+except ImportError:
+    pass
 
 from .packet import Packet
 
@@ -20,20 +27,20 @@ from .packet import Packet
 class _XYZPacket(Packet):
     """A packet of x, y, z float values. Used for several different Bluefruit controller packets."""
 
-    _FMT_PARSE = "<xxfffx"
-    PACKET_LENGTH = struct.calcsize(_FMT_PARSE)
+    _FMT_PARSE: str = "<xxfffx"
+    PACKET_LENGTH: int = struct.calcsize(_FMT_PARSE)
     # _FMT_CONSTRUCT doesn't include the trailing checksum byte.
-    _FMT_CONSTRUCT = "<2sfff"
+    _FMT_CONSTRUCT: str = "<2sfff"
     # _TYPE_HEADER is set by each concrete subclass.
 
-    def __init__(self, x, y, z):
+    def __init__(self, x: float, y: float, z: float) -> None:
         # Construct an _XYZPacket subclass object
         # from the given x, y, and z float values, and type character.
         self._x = x
         self._y = y
         self._z = z
 
-    def to_bytes(self):
+    def to_bytes(self) -> bytes:
         """Return the bytes needed to send this packet."""
         partial_packet = struct.pack(
             self._FMT_CONSTRUCT, self._TYPE_HEADER, self._x, self._y, self._z
@@ -41,16 +48,16 @@ class _XYZPacket(Packet):
         return self.add_checksum(partial_packet)
 
     @property
-    def x(self):
+    def x(self) -> float:
         """The x value."""
         return self._x
 
     @property
-    def y(self):
+    def y(self) -> float:
         """The y value."""
         return self._y
 
     @property
-    def z(self):
+    def z(self) -> float:
         """The z value."""
         return self._z

--- a/adafruit_bluefruit_connect/accelerometer_packet.py
+++ b/adafruit_bluefruit_connect/accelerometer_packet.py
@@ -12,14 +12,20 @@ Bluefruit Connect App Accelerometer data packet.
 
 """
 
+from __future__ import annotations
+
 from ._xyz_packet import _XYZPacket
 
+try:
+    from typing import Generator, Union, Dict, Optional, Any # adjust these as needed
+except ImportError:
+    pass
 
 class AccelerometerPacket(_XYZPacket):
     """A packet of x, y, z float values from an accelerometer."""
 
     # Everything else is handled by _XYZPacket.
-    _TYPE_HEADER = b"!A"
+    _TYPE_HEADER: bytes = b"!A"
 
 
 # Register this class with the superclass. This allows the user to import only what is needed.

--- a/adafruit_bluefruit_connect/accelerometer_packet.py
+++ b/adafruit_bluefruit_connect/accelerometer_packet.py
@@ -16,10 +16,6 @@ from __future__ import annotations
 
 from ._xyz_packet import _XYZPacket
 
-try:
-    from typing import Generator, Union, Dict, Optional, Any # adjust these as needed
-except ImportError:
-    pass
 
 class AccelerometerPacket(_XYZPacket):
     """A packet of x, y, z float values from an accelerometer."""

--- a/adafruit_bluefruit_connect/button_packet.py
+++ b/adafruit_bluefruit_connect/button_packet.py
@@ -13,39 +13,45 @@ Bluefruit Connect App Button data packet (button_name, pressed/released)
 
 """
 
+from __future__ import annotations
+
 import struct
 
 from .packet import Packet
 
+try:
+    from typing import Optional # adjust these as needed
+except ImportError:
+    pass
 
 class ButtonPacket(Packet):
     """A packet containing a button name and its state."""
 
-    BUTTON_1 = "1"
+    BUTTON_1: str = "1"
     """Code for Button 1 on the Bluefruit LE Connect app Control Pad screen."""
-    BUTTON_2 = "2"
+    BUTTON_2: str = "2"
     """Button 2."""
-    BUTTON_3 = "3"
+    BUTTON_3: str = "3"
     """Button 3."""
-    BUTTON_4 = "4"
+    BUTTON_4: str = "4"
     """Button 4."""
     # pylint: disable= invalid-name
-    UP = "5"
+    UP: str = "5"
     """Up Button."""
-    DOWN = "6"
+    DOWN: str = "6"
     """Down Button."""
-    LEFT = "7"
+    LEFT: str = "7"
     """Left Button."""
-    RIGHT = "8"
+    RIGHT: str = "8"
     """Right Button."""
 
-    _FMT_PARSE = "<xxssx"
-    PACKET_LENGTH = struct.calcsize(_FMT_PARSE)
+    _FMT_PARSE: str = "<xxssx"
+    PACKET_LENGTH: int = struct.calcsize(_FMT_PARSE)
     # _FMT_CONSTRUCT doesn't include the trailing checksum byte.
-    _FMT_CONSTRUCT = "<2sss"
-    _TYPE_HEADER = b"!B"
+    _FMT_CONSTRUCT: str = "<2sss"
+    _TYPE_HEADER: bytes = b"!B"
 
-    def __init__(self, button, pressed):
+    def __init__(self, button: str, pressed: bool) -> None:
         """Construct a ButtonPacket from a button name and the button's state.
 
         :param str button: a single character denoting the button
@@ -59,11 +65,11 @@ class ButtonPacket(Packet):
         except Exception as err:
             raise ValueError("Button must be a single char.") from err
 
-        self._button = button
-        self._pressed = pressed
+        self._button: str = button
+        self._pressed: bool = pressed
 
     @classmethod
-    def parse_private(cls, packet):
+    def parse_private(cls, packet: bytes) -> Optional[Packet]:
         """Construct a ButtonPacket from an incoming packet.
         Do not call this directly; call Packet.from_bytes() instead.
         pylint makes it difficult to call this method _parse(), hence the name.
@@ -73,9 +79,9 @@ class ButtonPacket(Packet):
             raise ValueError("Bad button press/release value")
         return cls(chr(button[0]), pressed == b"1")
 
-    def to_bytes(self):
+    def to_bytes(self) -> bytes:
         """Return the bytes needed to send this packet."""
-        partial_packet = struct.pack(
+        partial_packet: bytes = struct.pack(
             self._FMT_CONSTRUCT,
             self._TYPE_HEADER,
             bytes(self._button, "utf-8"),
@@ -84,13 +90,13 @@ class ButtonPacket(Packet):
         return self.add_checksum(partial_packet)
 
     @property
-    def button(self):
+    def button(self) -> str:
         """A single character string (not bytes) specifying the button that
         the user pressed or released."""
         return self._button
 
     @property
-    def pressed(self):
+    def pressed(self) -> bool:
         """``True`` if button is pressed, or ``False`` if it is released."""
         return self._pressed
 

--- a/adafruit_bluefruit_connect/button_packet.py
+++ b/adafruit_bluefruit_connect/button_packet.py
@@ -20,9 +20,10 @@ import struct
 from .packet import Packet
 
 try:
-    from typing import Optional # adjust these as needed
+    from typing import Optional  # adjust these as needed
 except ImportError:
     pass
+
 
 class ButtonPacket(Packet):
     """A packet containing a button name and its state."""

--- a/adafruit_bluefruit_connect/color_packet.py
+++ b/adafruit_bluefruit_connect/color_packet.py
@@ -12,21 +12,27 @@ Bluefruit Connect App color data packet.
 
 """
 
+from __future__ import annotations
+
 import struct
 
 from .packet import Packet
 
+try:
+    from typing import Optional # adjust these as needed
+except ImportError:
+    pass
 
 class ColorPacket(Packet):
     """A packet containing an RGB color value."""
 
-    _FMT_PARSE = "<xx3Bx"
-    PACKET_LENGTH = struct.calcsize(_FMT_PARSE)
+    _FMT_PARSE: str = "<xx3Bx"
+    PACKET_LENGTH: int = struct.calcsize(_FMT_PARSE)
     # _FMT_CONSTRUCT doesn't include the trailing checksum byte.
-    _FMT_CONSTRUCT = "<2s3B"
-    _TYPE_HEADER = b"!C"
+    _FMT_CONSTRUCT: str = "<2s3B"
+    _TYPE_HEADER: bytes = b"!C"
 
-    def __init__(self, color):
+    def __init__(self, color: Optional[Packet]) -> None:
         """Construct a ColorPacket from a 3-element :class:`tuple` of RGB
         values, or from an int color value 0xRRGGBB.
 
@@ -41,14 +47,14 @@ class ColorPacket(Packet):
             raise ValueError("Color must be an integer 0xRRGGBB or a tuple(r,g,b)")
 
     @classmethod
-    def parse_private(cls, packet):
+    def parse_private(cls, packet: Optional[Packet]) -> Optional[Packet]:
         """Construct a ColorPacket from an incoming packet.
         Do not call this directly; call Packet.from_bytes() instead.
         pylint makes it difficult to call this method _parse(), hence the name.
         """
         return cls(struct.unpack(cls._FMT_PARSE, packet))
 
-    def to_bytes(self):
+    def to_bytes(self) -> bytes:
         """Return the bytes needed to send this packet."""
         partial_packet = struct.pack(
             self._FMT_CONSTRUCT, self._TYPE_HEADER, *self._color
@@ -56,7 +62,7 @@ class ColorPacket(Packet):
         return self.add_checksum(partial_packet)
 
     @property
-    def color(self):
+    def color(self) -> tuple:
         """A :class:`tuple` ``(red, green blue)`` representing the color the
         user chose in the BlueFruit Connect app."""
         return self._color

--- a/adafruit_bluefruit_connect/color_packet.py
+++ b/adafruit_bluefruit_connect/color_packet.py
@@ -19,9 +19,10 @@ import struct
 from .packet import Packet
 
 try:
-    from typing import Optional # adjust these as needed
+    from typing import Optional  # adjust these as needed
 except ImportError:
     pass
+
 
 class ColorPacket(Packet):
     """A packet containing an RGB color value."""

--- a/adafruit_bluefruit_connect/color_packet.py
+++ b/adafruit_bluefruit_connect/color_packet.py
@@ -19,7 +19,7 @@ import struct
 from .packet import Packet
 
 try:
-    from typing import Optional  # adjust these as needed
+    from typing import Optional, Tuple  # adjust these as needed
 except ImportError:
     pass
 
@@ -33,7 +33,7 @@ class ColorPacket(Packet):
     _FMT_CONSTRUCT: str = "<2s3B"
     _TYPE_HEADER: bytes = b"!C"
 
-    def __init__(self, color: Optional[Packet]) -> None:
+    def __init__(self, color: Tuple) -> None:
         """Construct a ColorPacket from a 3-element :class:`tuple` of RGB
         values, or from an int color value 0xRRGGBB.
 
@@ -41,14 +41,14 @@ class ColorPacket(Packet):
           or an int color value ``0xRRGGBB``
         """
         if isinstance(color, int):
-            self._color = tuple(color.to_bytes(3, "big"))
+            self._color: Tuple = tuple(color.to_bytes(3, "big"))
         elif len(color) == 3 and all(0 <= c <= 255 for c in color):
             self._color = color
         else:
             raise ValueError("Color must be an integer 0xRRGGBB or a tuple(r,g,b)")
 
     @classmethod
-    def parse_private(cls, packet: Optional[Packet]) -> Optional[Packet]:
+    def parse_private(cls, packet: bytes) -> Optional[Packet]:
         """Construct a ColorPacket from an incoming packet.
         Do not call this directly; call Packet.from_bytes() instead.
         pylint makes it difficult to call this method _parse(), hence the name.

--- a/adafruit_bluefruit_connect/gyro_packet.py
+++ b/adafruit_bluefruit_connect/gyro_packet.py
@@ -12,6 +12,8 @@ Bluefruit Connect App Gyro data packet.
 
 """
 
+from __future__ import annotations
+
 from ._xyz_packet import _XYZPacket
 
 
@@ -19,7 +21,7 @@ class GyroPacket(_XYZPacket):
     """A packet of x, y, z float values from a gyroscope."""
 
     # Everything else is handled by _XYZPacket.
-    _TYPE_HEADER = b"!G"
+    _TYPE_HEADER: bytes = b"!G"
 
 
 # Register this class with the superclass. This allows the user to import only what is needed.

--- a/adafruit_bluefruit_connect/location_packet.py
+++ b/adafruit_bluefruit_connect/location_packet.py
@@ -12,6 +12,8 @@ Bluefruit Connect App geographical location packet.
 
 """
 
+from __future__ import annotations
+
 import struct
 
 from .packet import Packet
@@ -20,19 +22,19 @@ from .packet import Packet
 class LocationPacket(Packet):
     """A packet of latitude, longitude, and altitude values."""
 
-    _FMT_PARSE = "<xxfffx"
-    PACKET_LENGTH = struct.calcsize(_FMT_PARSE)
+    _FMT_PARSE: str = "<xxfffx"
+    PACKET_LENGTH: int = struct.calcsize(_FMT_PARSE)
     # _FMT_CONSTRUCT doesn't include the trailing checksum byte.
-    _FMT_CONSTRUCT = "<2sfff"
-    _TYPE_HEADER = b"!L"
+    _FMT_CONSTRUCT: str = "<2sfff"
+    _TYPE_HEADER: bytes = b"!L"
 
-    def __init__(self, latitude, longitude, altitude):
+    def __init__(self, latitude: float, longitude: float, altitude: float) -> None:
         """Construct a LocationPacket from the given values."""
         self._latitude = latitude
         self._longitude = longitude
         self._altitude = altitude
 
-    def to_bytes(self):
+    def to_bytes(self) -> bytes:
         """Return the bytes needed to send this packet."""
         partial_packet = struct.pack(
             self._FMT_CONSTRUCT,
@@ -44,17 +46,17 @@ class LocationPacket(Packet):
         return self.add_checksum(partial_packet)
 
     @property
-    def latitude(self):
+    def latitude(self) -> float:
         """The latitude value."""
         return self._latitude
 
     @property
-    def longitude(self):
+    def longitude(self) -> float:
         """The longitude value."""
         return self._longitude
 
     @property
-    def altitude(self):
+    def altitude(self) -> float:
         """The altitude value."""
         return self._altitude
 

--- a/adafruit_bluefruit_connect/magnetometer_packet.py
+++ b/adafruit_bluefruit_connect/magnetometer_packet.py
@@ -12,6 +12,8 @@ Bluefruit Connect App Magnetometer data packet.
 
 """
 
+from __future__ import annotations
+
 from ._xyz_packet import _XYZPacket
 
 
@@ -19,7 +21,7 @@ class MagnetometerPacket(_XYZPacket):
     """A packet of x, y, z float values from a magnetometer."""
 
     # Everything else is handled by _XYZPacket.
-    _TYPE_HEADER = b"!M"
+    _TYPE_HEADER: bytes = b"!M"
 
 
 # Register this class with the superclass. This allows the user to import only what is needed.

--- a/adafruit_bluefruit_connect/packet.py
+++ b/adafruit_bluefruit_connect/packet.py
@@ -15,10 +15,11 @@ Bluefruit Connect App packet superclass
 from __future__ import annotations
 
 import struct
-from io import RawIOBase
+
 
 try:
     from typing import Optional, Any  # adjust these as needed
+    from io import RawIOBase
 except ImportError:
     pass
 

--- a/adafruit_bluefruit_connect/packet.py
+++ b/adafruit_bluefruit_connect/packet.py
@@ -42,9 +42,9 @@ class Packet:
     # In each class, set PACKET_LENGTH = struct.calcsize(_FMT_PARSE).
     PACKET_LENGTH: int
     # _FMT_CONSTRUCT does not include the trailing byte, which is the checksum.
-    _FMT_CONSTRUCT = None
+    _FMT_CONSTRUCT: Optional[str] = None
     # The first byte of the prefix is always b'!'. The second byte is the type code.
-    _TYPE_HEADER = None
+    _TYPE_HEADER: Optional[bytearray] = None
 
     _type_to_class: dict = {}
 

--- a/adafruit_bluefruit_connect/packet.py
+++ b/adafruit_bluefruit_connect/packet.py
@@ -18,7 +18,7 @@ import struct
 from io import RawIOBase
 
 try:
-    from typing import Union, Optional, Any # adjust these as needed
+    from typing import Optional, Any # adjust these as needed
 except ImportError:
     pass
 
@@ -133,7 +133,7 @@ class Packet:
         return cls.from_bytes(packet)
 
     @classmethod
-    def parse_private(cls, packet: bytes) -> Packet:
+    def parse_private(cls, packet: bytes) -> Optional[Packet]:
         """Default implementation for subclasses.
         Assumes arguments to ``__init__()`` are exactly the values parsed using
         ``cls._FMT_PARSE``. Subclasses may need to reimplement if that assumption

--- a/adafruit_bluefruit_connect/packet.py
+++ b/adafruit_bluefruit_connect/packet.py
@@ -44,7 +44,7 @@ class Packet:
     # _FMT_CONSTRUCT does not include the trailing byte, which is the checksum.
     _FMT_CONSTRUCT: Optional[str] = None
     # The first byte of the prefix is always b'!'. The second byte is the type code.
-    _TYPE_HEADER: Optional[bytearray] = None
+    _TYPE_HEADER: Optional[bytes] = None
 
     _type_to_class: dict = {}
 

--- a/adafruit_bluefruit_connect/packet.py
+++ b/adafruit_bluefruit_connect/packet.py
@@ -18,9 +18,10 @@ import struct
 from io import RawIOBase
 
 try:
-    from typing import Optional, Any # adjust these as needed
+    from typing import Optional, Any  # adjust these as needed
 except ImportError:
     pass
+
 
 class Packet:
     """

--- a/adafruit_bluefruit_connect/quaternion_packet.py
+++ b/adafruit_bluefruit_connect/quaternion_packet.py
@@ -12,6 +12,8 @@ Bluefruit Connect App Quaternion data packet.
 
 """
 
+from __future__ import annotations
+
 import struct
 
 from ._xyz_packet import _XYZPacket
@@ -23,18 +25,18 @@ class QuaternionPacket(_XYZPacket):
 
     # Use _XYZPacket to handle x, y, z, and add w.
 
-    _FMT_PARSE = "<xxffffx"
-    PACKET_LENGTH = struct.calcsize(_FMT_PARSE)
+    _FMT_PARSE: str = "<xxffffx"
+    PACKET_LENGTH: int = struct.calcsize(_FMT_PARSE)
     # _FMT_CONSTRUCT doesn't include the trailing checksum byte.
-    _FMT_CONSTRUCT = "<2sffff"
-    _TYPE_HEADER = b"!Q"
+    _FMT_CONSTRUCT: str = "<2sffff"
+    _TYPE_HEADER: bytes = b"!Q"
 
-    def __init__(self, x, y, z, w):
+    def __init__(self, x: float, y: float, z: float, w: float) -> None:
         """Construct a QuaternionPacket from the given x, y, z, and w float values."""
         super().__init__(x, y, z)
         self._w = w
 
-    def to_bytes(self):
+    def to_bytes(self) -> bytes:
         """Return the bytes needed to send this packet."""
         partial_packet = struct.pack(
             self._FMT_CONSTRUCT, self._TYPE_HEADER, self._x, self._y, self._z, self._w
@@ -42,7 +44,7 @@ class QuaternionPacket(_XYZPacket):
         return partial_packet + self.checksum(partial_packet)
 
     @property
-    def w(self):
+    def w(self) -> float:
         """The w value."""
         return self._w
 

--- a/adafruit_bluefruit_connect/quaternion_packet.py
+++ b/adafruit_bluefruit_connect/quaternion_packet.py
@@ -41,7 +41,8 @@ class QuaternionPacket(_XYZPacket):
         partial_packet = struct.pack(
             self._FMT_CONSTRUCT, self._TYPE_HEADER, self._x, self._y, self._z, self._w
         )
-        return partial_packet + self.checksum(partial_packet)
+        return partial_packet + bytes((self.checksum(partial_packet),))
+    
 
     @property
     def w(self) -> float:

--- a/adafruit_bluefruit_connect/quaternion_packet.py
+++ b/adafruit_bluefruit_connect/quaternion_packet.py
@@ -42,7 +42,6 @@ class QuaternionPacket(_XYZPacket):
             self._FMT_CONSTRUCT, self._TYPE_HEADER, self._x, self._y, self._z, self._w
         )
         return partial_packet + bytes((self.checksum(partial_packet),))
-    
 
     @property
     def w(self) -> float:

--- a/adafruit_bluefruit_connect/raw_text_packet.py
+++ b/adafruit_bluefruit_connect/raw_text_packet.py
@@ -22,23 +22,25 @@ Consequently, this packet type is MUCH simpler than the other packet types.
 
 """
 
+from __future__ import annotations
+
 from .packet import Packet
 
 
 class RawTextPacket(Packet):
     """A packet containing a text string."""
 
-    _TYPE_HEADER = b"RT"
+    _TYPE_HEADER: bytes = b"RT"
 
-    def __init__(self, text):
+    def __init__(self, text: str) -> None:
         """Construct a RawTextPacket from a binary string."""
         if isinstance(text, bytes):
-            self._text = text.strip()
+            self._text: str = text.strip()
         else:
             raise ValueError("Text must be a bytes string")
 
     @property
-    def text(self):
+    def text(self) -> str:
         """Return the text associated with the object."""
         return self._text
 


### PR DESCRIPTION
Still failing mypy and I have some questions to pose regarding the quaternion_packet.py script on line 44.

I need to head home, but I will continue working on this in the coming days. Here are the mypy results:

```

adafruit_bluefruit_connect\packet.py:70: error: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior  [str-bytes-safe]
adafruit_bluefruit_connect\packet.py:130: error: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior  [str-bytes-safe]
adafruit_bluefruit_connect\color_packet.py:45: error: Argument 1 to "len" has incompatible type "Optional[Packet]"; 
expected "Sized"  [arg-type]
adafruit_bluefruit_connect\color_packet.py:45: error: Item "Packet" of "Optional[Packet]" has no attribute "__iter__" (not iterable)  [union-attr]
adafruit_bluefruit_connect\color_packet.py:45: error: Item "None" of "Optional[Packet]" has no attribute "__iter__" 
(not iterable)  [union-attr]
adafruit_bluefruit_connect\color_packet.py:46: error: Cannot determine type of "_color"  [has-type]
adafruit_bluefruit_connect\color_packet.py:51: error: Argument 1 of "parse_private" is incompatible with supertype "Packet"; supertype defines the argument type as "bytes"  [override]
adafruit_bluefruit_connect\color_packet.py:51: note: This violates the Liskov substitution principle
adafruit_bluefruit_connect\color_packet.py:51: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
adafruit_bluefruit_connect\color_packet.py:56: error: Argument 1 to "ColorPacket" has incompatible type "Tuple[Any, 
...]"; expected "Optional[Packet]"  [arg-type]
adafruit_bluefruit_connect\color_packet.py:56: error: Argument 2 to "unpack" has incompatible type "Optional[Packet]"; expected "Union[bytes, Union[bytearray, memoryview, array[Any], mmap, _CData, PickleBuffer]]"  [arg-type]        
adafruit_bluefruit_connect\color_packet.py:61: error: Cannot determine type of "_color"  [has-type]
adafruit_bluefruit_connect\color_packet.py:69: error: Cannot determine type of "_color"  [has-type]
adafruit_bluefruit_connect\quaternion_packet.py:44: error: Unsupported operand types for + ("bytes" and "int")  [operator]
Found 12 errors in 3 files (checked 11 source files)```