### PR TITLE
Corrected file name in examples.rst 

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -28,6 +28,6 @@ This example demonstrates receiving text from the UART interface.
 This example demonstrates receiving both a color (as in simpletest above)
 and raw text (using RawTextPacket).
 
-.. literalinclude:: ../examples/bluefruitconnect_simpletest.py
-    :caption: examples/bluefruitconnect_simpletest.py
+.. literalinclude:: ../examples/bluefruitconnect_simpletest2.py
+    :caption: examples/bluefruitconnect_simpletest2.py
     :linenos:


### PR DESCRIPTION
Changed  bluefruitconnect_simpletest.py to bluefruitconnect_simpletest2.py in examples.rst for the last example reference. Originally the same code was referenced in both cases.
WAS:
This example demonstrates receiving both a color (as in simpletest above)
and raw text (using RawTextPacket).

.. literalinclude:: ../examples/bluefruitconnect_simpletest.py
    :caption: examples/bluefruitconnect_simpletest.py
    :linenos:
IS:
This example demonstrates receiving both a color (as in simpletest above)
and raw text (using RawTextPacket).

.. literalinclude:: ../examples/bluefruitconnect_simpletest2.py
    :caption: examples/bluefruitconnect_simpletest2.py
    :linenos: