### PR TITLE
image_parser class and receiver example.

### DIFF
--- a/adafruit_bluefruit_connect/image_parser.py
+++ b/adafruit_bluefruit_connect/image_parser.py
@@ -22,117 +22,114 @@ class BLEImageParser:
     Writes pixels to bitmap as data arrives without buffering the full image.
     """
 
-    def __init__(self, bitmap):
-        """
-        Initialize the parser.
+    def __init__(self, bitmap, debug=False):
+        """Initialize the parser.
 
-        Args:
-            bitmap: 2D array-like object that supports bitmap[x, y] = value assignment
+        :param Bitmap bitmap: The Bitmap object to write image data into
+        :param bool debug: Whether to enable debug prints
         """
         self.bitmap = bitmap
+        self.debug = debug
         self.reset()
 
     def reset(self):
         """Reset the parser state for a new image."""
-        self.header_buffer = bytearray()
-        self.partial_pixel = bytearray()  # For incomplete pixel at chunk boundary
-        self.header_parsed = False
-        self.width = 0
-        self.height = 0
-        self.color_space = 0
-        self.expected_total_size = 0
-        self.bytes_received = 0
-        self.current_x = 0
-        self.current_y = 0
-        self.crc_byte = None
+        self._header_buffer = bytearray()
+        self._partial_pixel = bytearray()  # For incomplete pixel at chunk boundary
+        self._header_parsed = False
+        self._width = 0
+        self._height = 0
+        self._color_space = 0
+        self._expected_total_size = 0
+        self._bytes_received = 0
+        self._current_x = 0
+        self._current_y = 0
+        self._crc_byte = None
 
     def add_chunk(self, chunk_data):
         """
         Add a chunk of data to the parser.
 
-        Args:
-            chunk_data: bytes or bytearray containing a chunk of image data
+        :param chunk_data: bytes or bytearray containing a chunk of image data.
+            Raises ValueError if the data format is invalid
 
-        Returns:
-            True if the complete image has been received and parsed, False if more data needed
-
-        Raises:
-            ValueError if the data format is invalid
+        :return: True if the complete image has been received and parsed, False if more data needed
         """
         chunk_idx = 0
 
         # Parse header if we haven't yet
-        if not self.header_parsed:
+        if not self._header_parsed:
             # Add to header buffer
-            bytes_needed = 7 - len(self.header_buffer)
+            bytes_needed = 7 - len(self._header_buffer)
             bytes_to_take = min(bytes_needed, len(chunk_data))
-            self.header_buffer.extend(chunk_data[chunk_idx : chunk_idx + bytes_to_take])
+            self._header_buffer.extend(chunk_data[chunk_idx : chunk_idx + bytes_to_take])
             chunk_idx += bytes_to_take
-            self.bytes_received += bytes_to_take
+            self._bytes_received += bytes_to_take
 
             # Check if we have complete header
-            if len(self.header_buffer) >= 7:
+            if len(self._header_buffer) >= 7:
                 # Check magic bytes
-                if self.header_buffer[0] != 0x21 or self.header_buffer[1] != 0x49:
+                if self._header_buffer[0] != 0x21 or self._header_buffer[1] != 0x49:
                     raise ValueError("Invalid magic bytes")
 
                 # Get color space
-                self.color_space = self.header_buffer[2]
+                self._color_space = self._header_buffer[2]
 
-                if self.color_space != 16:
-                    raise ValueError(f"Only 16-bit 565 format supported, got {self.color_space}")
+                if self._color_space != 16:
+                    raise ValueError(f"Only 16-bit 565 format supported, got {self._color_space}")
 
                 # Get width (uint16 little endian)
-                self.width = self.header_buffer[3] | (self.header_buffer[4] << 8)
+                self._width = self._header_buffer[3] | (self._header_buffer[4] << 8)
 
                 # Get height (uint16 little endian)
-                self.height = self.header_buffer[5] | (self.header_buffer[6] << 8)
+                self._height = self._header_buffer[5] | (self._header_buffer[6] << 8)
 
                 # Calculate expected total size
                 bytes_per_pixel = 2  # 16-bit = 2 bytes
-                pixel_data_size = self.width * self.height * bytes_per_pixel
-                self.expected_total_size = 7 + pixel_data_size + 1  # header + pixels + CRC
+                pixel_data_size = self._width * self._height * bytes_per_pixel
+                self._expected_total_size = 7 + pixel_data_size + 1  # header + pixels + CRC
 
-                self.header_parsed = True
-                print(f"Header parsed: {self.width}x{self.height}, {self.color_space}-bit")
-                print(f"Expected total size: {self.expected_total_size} bytes")
+                self._header_parsed = True
+                if self.debug:
+                    print(f"Header parsed: {self._width}x{self._height}, {self._color_space}-bit")
+                    print(f"Expected total size: {self._expected_total_size} bytes")
 
                 # Clear header buffer to free memory
-                self.header_buffer = bytearray()
+                self._header_buffer = bytearray()
 
         # Process pixel data
-        if self.header_parsed and chunk_idx < len(chunk_data):
+        if self._header_parsed and chunk_idx < len(chunk_data):
             # Handle partial pixel from previous chunk
-            if len(self.partial_pixel) > 0:
-                bytes_needed = 2 - len(self.partial_pixel)
+            if len(self._partial_pixel) > 0:
+                bytes_needed = 2 - len(self._partial_pixel)
                 bytes_to_take = min(bytes_needed, len(chunk_data) - chunk_idx)
-                self.partial_pixel.extend(chunk_data[chunk_idx : chunk_idx + bytes_to_take])
+                self._partial_pixel.extend(chunk_data[chunk_idx : chunk_idx + bytes_to_take])
                 chunk_idx += bytes_to_take
-                self.bytes_received += bytes_to_take
+                self._bytes_received += bytes_to_take
 
                 # If we now have a complete pixel, write it
-                if len(self.partial_pixel) == 2:
-                    pixel_565 = self.partial_pixel[0] | (self.partial_pixel[1] << 8)
-                    self.bitmap[self.current_x, self.current_y] = pixel_565
+                if len(self._partial_pixel) == 2:
+                    pixel_565 = self._partial_pixel[0] | (self._partial_pixel[1] << 8)
+                    self.bitmap[self._current_x, self._current_y] = pixel_565
 
                     # Advance position
-                    self.current_x += 1
-                    if self.current_x >= self.width:
-                        self.current_x = 0
-                        self.current_y += 1
+                    self._current_x += 1
+                    if self._current_x >= self._width:
+                        self._current_x = 0
+                        self._current_y += 1
 
-                    self.partial_pixel = bytearray()
+                    self._partial_pixel = bytearray()
 
             # Process remaining complete pixels in this chunk
             while chunk_idx + 1 < len(chunk_data):
                 # Check if we've finished all pixels
-                pixels_written = self.current_y * self.width + self.current_x
-                total_pixels = self.width * self.height
+                pixels_written = self._current_y * self._width + self._current_x
+                total_pixels = self._width * self._height
 
                 if pixels_written >= total_pixels:
                     # We're at the CRC byte
-                    self.crc_byte = chunk_data[chunk_idx]
-                    self.bytes_received += 1
+                    self._crc_byte = chunk_data[chunk_idx]
+                    self._bytes_received += 1
                     chunk_idx += 1
                     break
 
@@ -141,38 +138,39 @@ class BLEImageParser:
                 high_byte = chunk_data[chunk_idx + 1]
                 pixel_565 = low_byte | (high_byte << 8)
 
-                self.bitmap[self.current_x, self.current_y] = pixel_565
+                self.bitmap[self._current_x, self._current_y] = pixel_565
 
                 # Advance position
-                self.current_x += 1
-                if self.current_x >= self.width:
-                    self.current_x = 0
-                    self.current_y += 1
+                self._current_x += 1
+                if self._current_x >= self._width:
+                    self._current_x = 0
+                    self._current_y += 1
 
                 chunk_idx += 2
-                self.bytes_received += 2
+                self._bytes_received += 2
 
             # Handle incomplete pixel at end of chunk
             if chunk_idx < len(chunk_data):
-                pixels_written = self.current_y * self.width + self.current_x
-                total_pixels = self.width * self.height
+                pixels_written = self._current_y * self._width + self._current_x
+                total_pixels = self._width * self._height
 
                 if pixels_written < total_pixels:
                     # Save partial pixel for next chunk
-                    self.partial_pixel.extend(chunk_data[chunk_idx:])
-                    self.bytes_received += len(chunk_data) - chunk_idx
-                elif self.crc_byte is None:
+                    self._partial_pixel.extend(chunk_data[chunk_idx:])
+                    self._bytes_received += len(chunk_data) - chunk_idx
+                elif self._crc_byte is None:
                     # This must be the CRC byte
-                    self.crc_byte = chunk_data[chunk_idx]
-                    self.bytes_received += 1
+                    self._crc_byte = chunk_data[chunk_idx]
+                    self._bytes_received += 1
 
         # Check if we're complete
-        if self.bytes_received >= self.expected_total_size:
-            pixels_written = self.current_y * self.width + self.current_x
-            print(f"Successfully parsed {pixels_written} pixels")
+        if self._bytes_received >= self._expected_total_size:
+            pixels_written = self._current_y * self._width + self._current_x
+            if self.debug:
+                print(f"Successfully parsed {pixels_written} pixels")
 
             # Optional: Verify CRC
-            if self.crc_byte is not None:
+            if self._crc_byte is not None:
                 # crc_calculated = calculate_crc(...)
                 # if self.crc_byte != crc_calculated:
                 #     print("Warning: CRC mismatch")
@@ -181,5 +179,6 @@ class BLEImageParser:
             self.reset()
             return True
 
-        print(f"Progress: {self.bytes_received}/{self.expected_total_size} bytes received")
+        if self.debug:
+            print(f"Progress: {self._bytes_received}/{self._expected_total_size} bytes received")
         return False

--- a/adafruit_bluefruit_connect/image_parser.py
+++ b/adafruit_bluefruit_connect/image_parser.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2026 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_bluefruit_connect.image_parser`
+====================================================
+
+Parse chunks of data making up an image sent by the BLE Connect app.
+
+Current limitations:
+ - 16bit 565 format only
+
+* Author(s): Tim Cocks, Claude Sonnet 4.5
+
+"""
+
+
+class BLEImageParser:
+    """
+    Stateful parser for BLE image data received in chunks.
+    """
+
+    def __init__(self, bitmap):
+        """
+        Initialize the parser.
+
+        Args:
+            bitmap: 2D array-like object that supports bitmap[x, y] = value assignment
+        """
+        self.bitmap = bitmap
+        self.reset()
+
+    def reset(self):
+        """Reset the parser state for a new image."""
+        self.buffer = bytearray()
+        self.header_parsed = False
+        self.width = 0
+        self.height = 0
+        self.color_space = 0
+        self.expected_total_size = 0
+        self.pixels_written = 0
+
+    def add_chunk(self, chunk_data):
+        """
+        Add a chunk of data to the parser.
+
+        Args:
+            chunk_data: bytes or bytearray containing a chunk of image data
+
+        Returns:
+            True if the complete image has been received and parsed, False if more data needed
+
+        Raises:
+            ValueError if the data format is invalid
+        """
+        # Add chunk to buffer
+        self.buffer.extend(chunk_data)
+
+        # Parse header if we haven't yet
+        if not self.header_parsed:
+            # Need at least 7 bytes for header (without CRC)
+            if len(self.buffer) < 7:
+                return False  # Need more data
+
+            # Check magic bytes
+            if self.buffer[0] != 0x21 or self.buffer[1] != 0x49:
+                raise ValueError("Invalid magic bytes")
+
+            # Get color space
+            self.color_space = self.buffer[2]
+
+            if self.color_space != 16:
+                raise ValueError(f"Only 16-bit 565 format supported, got {self.color_space}")
+
+            # Get width (uint16 little endian)
+            self.width = self.buffer[3] | (self.buffer[4] << 8)
+
+            # Get height (uint16 little endian)
+            self.height = self.buffer[5] | (self.buffer[6] << 8)
+
+            # Calculate expected total size
+            bytes_per_pixel = 2  # 16-bit = 2 bytes
+            pixel_data_size = self.width * self.height * bytes_per_pixel
+            self.expected_total_size = 7 + pixel_data_size + 1  # header + pixels + CRC
+
+            self.header_parsed = True
+            print(f"Header parsed: {self.width}x{self.height}, {self.color_space}-bit")
+            print(f"Expected total size: {self.expected_total_size} bytes")
+
+        # Check if we have all the data yet
+        if len(self.buffer) < self.expected_total_size:
+            print(f"Progress: {len(self.buffer)}/{self.expected_total_size} bytes received")
+            return False  # Need more data
+
+        # We have all the data, parse the pixels
+        print("All data received, parsing pixels...")
+        self._parse_pixels()
+
+        return True  # Complete!
+
+    def _parse_pixels(self):
+        """Parse pixel data from the complete buffer."""
+        pixel_idx = 7  # Start after header
+
+        for y in range(self.height):
+            for x in range(self.width):
+                # Read 16-bit pixel (little endian)
+                low_byte = self.buffer[pixel_idx]
+                high_byte = self.buffer[pixel_idx + 1]
+                pixel_565 = low_byte | (high_byte << 8)
+                pixel_idx += 2
+
+                # Write to bitmap
+                self.bitmap[x, y] = pixel_565
+                self.pixels_written += 1
+
+        # Optional: Verify CRC
+        # crc_received = self.buffer[pixel_idx]
+        # crc_calculated = calculate_crc(self.buffer[0:pixel_idx])
+        # if crc_received != crc_calculated:
+        #     print("Warning: CRC mismatch")
+
+        print(f"Successfully parsed {self.pixels_written} pixels")

--- a/adafruit_bluefruit_connect/image_parser.py
+++ b/adafruit_bluefruit_connect/image_parser.py
@@ -19,6 +19,7 @@ Current limitations:
 class BLEImageParser:
     """
     Stateful parser for BLE image data received in chunks.
+    Writes pixels to bitmap as data arrives without buffering the full image.
     """
 
     def __init__(self, bitmap):
@@ -33,13 +34,17 @@ class BLEImageParser:
 
     def reset(self):
         """Reset the parser state for a new image."""
-        self.buffer = bytearray()
+        self.header_buffer = bytearray()
+        self.partial_pixel = bytearray()  # For incomplete pixel at chunk boundary
         self.header_parsed = False
         self.width = 0
         self.height = 0
         self.color_space = 0
         self.expected_total_size = 0
-        self.pixels_written = 0
+        self.bytes_received = 0
+        self.current_x = 0
+        self.current_y = 0
+        self.crc_byte = None
 
     def add_chunk(self, chunk_data):
         """
@@ -54,71 +59,127 @@ class BLEImageParser:
         Raises:
             ValueError if the data format is invalid
         """
-        # Add chunk to buffer
-        self.buffer.extend(chunk_data)
+        chunk_idx = 0
 
         # Parse header if we haven't yet
         if not self.header_parsed:
-            # Need at least 7 bytes for header (without CRC)
-            if len(self.buffer) < 7:
-                return False  # Need more data
+            # Add to header buffer
+            bytes_needed = 7 - len(self.header_buffer)
+            bytes_to_take = min(bytes_needed, len(chunk_data))
+            self.header_buffer.extend(chunk_data[chunk_idx : chunk_idx + bytes_to_take])
+            chunk_idx += bytes_to_take
+            self.bytes_received += bytes_to_take
 
-            # Check magic bytes
-            if self.buffer[0] != 0x21 or self.buffer[1] != 0x49:
-                raise ValueError("Invalid magic bytes")
+            # Check if we have complete header
+            if len(self.header_buffer) >= 7:
+                # Check magic bytes
+                if self.header_buffer[0] != 0x21 or self.header_buffer[1] != 0x49:
+                    raise ValueError("Invalid magic bytes")
 
-            # Get color space
-            self.color_space = self.buffer[2]
+                # Get color space
+                self.color_space = self.header_buffer[2]
 
-            if self.color_space != 16:
-                raise ValueError(f"Only 16-bit 565 format supported, got {self.color_space}")
+                if self.color_space != 16:
+                    raise ValueError(f"Only 16-bit 565 format supported, got {self.color_space}")
 
-            # Get width (uint16 little endian)
-            self.width = self.buffer[3] | (self.buffer[4] << 8)
+                # Get width (uint16 little endian)
+                self.width = self.header_buffer[3] | (self.header_buffer[4] << 8)
 
-            # Get height (uint16 little endian)
-            self.height = self.buffer[5] | (self.buffer[6] << 8)
+                # Get height (uint16 little endian)
+                self.height = self.header_buffer[5] | (self.header_buffer[6] << 8)
 
-            # Calculate expected total size
-            bytes_per_pixel = 2  # 16-bit = 2 bytes
-            pixel_data_size = self.width * self.height * bytes_per_pixel
-            self.expected_total_size = 7 + pixel_data_size + 1  # header + pixels + CRC
+                # Calculate expected total size
+                bytes_per_pixel = 2  # 16-bit = 2 bytes
+                pixel_data_size = self.width * self.height * bytes_per_pixel
+                self.expected_total_size = 7 + pixel_data_size + 1  # header + pixels + CRC
 
-            self.header_parsed = True
-            print(f"Header parsed: {self.width}x{self.height}, {self.color_space}-bit")
-            print(f"Expected total size: {self.expected_total_size} bytes")
+                self.header_parsed = True
+                print(f"Header parsed: {self.width}x{self.height}, {self.color_space}-bit")
+                print(f"Expected total size: {self.expected_total_size} bytes")
 
-        # Check if we have all the data yet
-        if len(self.buffer) < self.expected_total_size:
-            print(f"Progress: {len(self.buffer)}/{self.expected_total_size} bytes received")
-            return False  # Need more data
+                # Clear header buffer to free memory
+                self.header_buffer = bytearray()
 
-        # We have all the data, parse the pixels
-        print("All data received, parsing pixels...")
-        self._parse_pixels()
+        # Process pixel data
+        if self.header_parsed and chunk_idx < len(chunk_data):
+            # Handle partial pixel from previous chunk
+            if len(self.partial_pixel) > 0:
+                bytes_needed = 2 - len(self.partial_pixel)
+                bytes_to_take = min(bytes_needed, len(chunk_data) - chunk_idx)
+                self.partial_pixel.extend(chunk_data[chunk_idx : chunk_idx + bytes_to_take])
+                chunk_idx += bytes_to_take
+                self.bytes_received += bytes_to_take
 
-        return True  # Complete!
+                # If we now have a complete pixel, write it
+                if len(self.partial_pixel) == 2:
+                    pixel_565 = self.partial_pixel[0] | (self.partial_pixel[1] << 8)
+                    self.bitmap[self.current_x, self.current_y] = pixel_565
 
-    def _parse_pixels(self):
-        """Parse pixel data from the complete buffer."""
-        pixel_idx = 7  # Start after header
+                    # Advance position
+                    self.current_x += 1
+                    if self.current_x >= self.width:
+                        self.current_x = 0
+                        self.current_y += 1
 
-        for y in range(self.height):
-            for x in range(self.width):
-                # Read 16-bit pixel (little endian)
-                low_byte = self.buffer[pixel_idx]
-                high_byte = self.buffer[pixel_idx + 1]
+                    self.partial_pixel = bytearray()
+
+            # Process remaining complete pixels in this chunk
+            while chunk_idx + 1 < len(chunk_data):
+                # Check if we've finished all pixels
+                pixels_written = self.current_y * self.width + self.current_x
+                total_pixels = self.width * self.height
+
+                if pixels_written >= total_pixels:
+                    # We're at the CRC byte
+                    self.crc_byte = chunk_data[chunk_idx]
+                    self.bytes_received += 1
+                    chunk_idx += 1
+                    break
+
+                # Read complete pixel
+                low_byte = chunk_data[chunk_idx]
+                high_byte = chunk_data[chunk_idx + 1]
                 pixel_565 = low_byte | (high_byte << 8)
-                pixel_idx += 2
 
-                # Write to bitmap
-                self.bitmap[x, y] = pixel_565
-                self.pixels_written += 1
+                self.bitmap[self.current_x, self.current_y] = pixel_565
 
-        # Optional: Verify CRC
-        # crc_received = self.buffer[pixel_idx]
-        # crc_calculated = calculate_crc(self.buffer[0:pixel_idx])
-        # if crc_received != crc_calculated:
-        #     print("Warning: CRC mismatch")
+                # Advance position
+                self.current_x += 1
+                if self.current_x >= self.width:
+                    self.current_x = 0
+                    self.current_y += 1
 
-        print(f"Successfully parsed {self.pixels_written} pixels")
+                chunk_idx += 2
+                self.bytes_received += 2
+
+            # Handle incomplete pixel at end of chunk
+            if chunk_idx < len(chunk_data):
+                pixels_written = self.current_y * self.width + self.current_x
+                total_pixels = self.width * self.height
+
+                if pixels_written < total_pixels:
+                    # Save partial pixel for next chunk
+                    self.partial_pixel.extend(chunk_data[chunk_idx:])
+                    self.bytes_received += len(chunk_data) - chunk_idx
+                elif self.crc_byte is None:
+                    # This must be the CRC byte
+                    self.crc_byte = chunk_data[chunk_idx]
+                    self.bytes_received += 1
+
+        # Check if we're complete
+        if self.bytes_received >= self.expected_total_size:
+            pixels_written = self.current_y * self.width + self.current_x
+            print(f"Successfully parsed {pixels_written} pixels")
+
+            # Optional: Verify CRC
+            if self.crc_byte is not None:
+                # crc_calculated = calculate_crc(...)
+                # if self.crc_byte != crc_calculated:
+                #     print("Warning: CRC mismatch")
+                pass
+
+            self.reset()
+            return True
+
+        print(f"Progress: {self.bytes_received}/{self.expected_total_size} bytes received")
+        return False

--- a/examples/bluefruitconnect_image_receiver.py
+++ b/examples/bluefruitconnect_image_receiver.py
@@ -18,7 +18,8 @@ from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
 from adafruit_ble.services.nordic import UARTService
 from adafruit_gizmo import tft_gizmo
-from ble_image_parser import BLEImageParser
+
+from adafruit_bluefruit_connect.image_parser import BLEImageParser
 
 # Create the TFT Gizmo display
 display = tft_gizmo.TFT_Gizmo()
@@ -27,7 +28,7 @@ display = tft_gizmo.TFT_Gizmo()
 # Here we show how to draw random pixels
 
 # Create a bitmap with two colors
-bitmap = displayio.Bitmap(display.width // 2, display.height // 2, 65535)
+bitmap = displayio.Bitmap(128, 128, 65535)
 
 converter_565 = displayio.ColorConverter(input_colorspace=displayio.Colorspace.RGB565)
 
@@ -35,7 +36,7 @@ converter_565 = displayio.ColorConverter(input_colorspace=displayio.Colorspace.R
 tile_grid = displayio.TileGrid(bitmap, pixel_shader=converter_565)
 
 # Create a Group
-group = displayio.Group()
+group = displayio.Group(scale=2)
 
 # Add the TileGrid to the Group
 group.append(tile_grid)
@@ -50,6 +51,8 @@ parser = BLEImageParser(bitmap)
 ble = BLERadio()
 uart_server = UARTService()
 advertisement = ProvideServicesAdvertisement(uart_server)
+
+display.auto_refresh = False
 
 count = 0
 while True:
@@ -69,7 +72,9 @@ while True:
         # incoming data chunk
         if uart_server.in_waiting:
             raw_bytes = uart_server.read(uart_server.in_waiting)
-            parser.add_chunk(raw_bytes)
+            full_img_received = parser.add_chunk(raw_bytes)
+            if full_img_received:
+                display.refresh()
 
     # Disconnected
     print("DISCONNECTED")

--- a/examples/bluefruitconnect_image_receiver.py
+++ b/examples/bluefruitconnect_image_receiver.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Tim Cocks for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+"""
+Example for Playground Bluefruit + TFTGizmo that receives an image sent by the
+BLE Connect V2 mobile app.
+
+Current limitations:
+ - Maximum size image is 120x120. Not enough RAM for bigger
+ - 16bit 565 format only
+
+"""
+
+import time
+
+import displayio
+from adafruit_ble import BLERadio
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from adafruit_ble.services.nordic import UARTService
+from adafruit_gizmo import tft_gizmo
+from ble_image_parser import BLEImageParser
+
+# Create the TFT Gizmo display
+display = tft_gizmo.TFT_Gizmo()
+
+# You can now use the display to do whatever you want
+# Here we show how to draw random pixels
+
+# Create a bitmap with two colors
+bitmap = displayio.Bitmap(display.width // 2, display.height // 2, 65535)
+
+converter_565 = displayio.ColorConverter(input_colorspace=displayio.Colorspace.RGB565)
+
+# Create a TileGrid using the Bitmap and Palette
+tile_grid = displayio.TileGrid(bitmap, pixel_shader=converter_565)
+
+# Create a Group
+group = displayio.Group()
+
+# Add the TileGrid to the Group
+group.append(tile_grid)
+
+# Add the Group to the Display
+display.root_group = group
+
+# initialize image parser
+parser = BLEImageParser(bitmap)
+
+# set up BLE
+ble = BLERadio()
+uart_server = UARTService()
+advertisement = ProvideServicesAdvertisement(uart_server)
+
+count = 0
+while True:
+    print("WAITING...")
+    # Advertise when not connected.
+    ble.start_advertising(advertisement)
+    while not ble.connected:
+        pass
+
+    # Connected
+    ble.stop_advertising()
+    print("CONNECTED")
+
+    # Loop and read packets
+    last_send = time.monotonic()
+    while ble.connected:
+        # incoming data chunk
+        if uart_server.in_waiting:
+            raw_bytes = uart_server.read(uart_server.in_waiting)
+            parser.add_chunk(raw_bytes)
+
+    # Disconnected
+    print("DISCONNECTED")

--- a/examples/bluefruitconnect_image_receiver.py
+++ b/examples/bluefruitconnect_image_receiver.py
@@ -24,15 +24,13 @@ from adafruit_bluefruit_connect.image_parser import BLEImageParser
 # Create the TFT Gizmo display
 display = tft_gizmo.TFT_Gizmo()
 
-# You can now use the display to do whatever you want
-# Here we show how to draw random pixels
-
-# Create a bitmap with two colors
+# Create a bitmap with max color count
 bitmap = displayio.Bitmap(128, 128, 65535)
 
+# Color converter for RGB565 color coming from BLE and going into displayio
 converter_565 = displayio.ColorConverter(input_colorspace=displayio.Colorspace.RGB565)
 
-# Create a TileGrid using the Bitmap and Palette
+# Create a TileGrid using the Bitmap and ColorConverter
 tile_grid = displayio.TileGrid(bitmap, pixel_shader=converter_565)
 
 # Create a Group


### PR DESCRIPTION
Resolves: #16 

I am working on the Android BLE Connect V2 app. Some of the APIs around image selection are different and I went looking for example code for the MCU side of that image transfer but couldn't find any so had claude take a crack at a parser and I made some example code to use it.

Adds a new BLEImageParser class mostly implemented by Claude sonnet 4.5 with a few tweaks by me. 

Adds new bluefruitconnect_image_receiver.py example that uses the parser class to show a received image on the CPB+Gizmo.


Some possible changes/enhancements we might want to consider:
- remove the prints from the parser class, or add a debug argument to disable them by default to keep serial output cleaner
- Implement 24bit 888 color handling. Right now only 565 is supported, but I think 888 shouldn't be hard to add with an additional ColorConverter object.
- Handle interrupted data stream gracefully. Not sure exactly what would happen if the an image transfer starts but doesn't finish. I suspect it would need to have `reset()` called manually in order to be able successfully receive subsequent image transfers.